### PR TITLE
Add support for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java 
+jdk:
+  - oraclejdk8


### PR DESCRIPTION
This file adds the ability for travis to perform tests on the gradle project. Travis will auto detect the gradle project 🌟

For more info, see http://docs.travis-ci.com/user/languages/java/.
